### PR TITLE
Fixing production URL not in allowed hosts bug

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,6 +9,6 @@ COPY ./ /app/
 
 # install npm packages
 RUN npm install
-RUN npm install axios dotenv
+RUN npm install axios
 
 CMD ["npm", "run", "dev", "--", "--host"]

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,10 +1,23 @@
 import axios from 'axios';
-import { API_URL } from '../vite.config';
+
+// Import staging or production environment variable
+const environment = import.meta.env.STAGING_OR_PROD;
+
+// Define appropriate environment API url
+const API_URL =
+  environment === "PROD"
+    ? "https://ecommerce-api-production-50293729231.europe-west10.run.app"
+    : "https://product-recs-api-50293729231.europe-west10.run.app";
+
+console.log(`Using API URL: ${API_URL}`);
+
+
 
 // Create an instance of axios with the base url
 const api = axios.create({
     baseURL : API_URL
 });
+
 
 // Export api instance
 export default api;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,24 +1,5 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import dotenv from 'dotenv';
-
-// Load environment variables
-dotenv.config();
-const environment = process.env.STAGING_OR_PROD;
-
-// Define appropriate environment API url
-export const API_URL =
-  environment === "PROD"
-    ? "https://ecommerce-api-production-50293729231.europe-west10.run.app"
-    : "https://product-recs-api-50293729231.europe-west10.run.app";
-console.log(`Using API URL: ${API_URL}`);
-
-
-// Define allowed hosts for frontend URL
-const FRONTEND_URL = 
-  environment === "PROD"
-    ? "web-app-frontend-production-50293729231.europe-west10.run.app"
-    : "web-app-frontend-50293729231.europe-west10.run.app";
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -26,8 +7,9 @@ export default defineConfig({
   server: {
     host: "0.0.0.0", // Allow external access (needed for Docker & Cloud Run)
     port: 5173, // Ensure Vite runs on the correct port
-    allowedHosts: [
-      FRONTEND_URL // Allow Cloud Run Frontend domain
+    allowedHosts: [  // Allow Cloud Run Frontend domain
+      "web-app-frontend-production-50293729231.europe-west10.run.app",
+      "web-app-frontend-50293729231.europe-west10.run.app" 
     ]
   }
 })


### PR DESCRIPTION
Abandoned FRONTEND_URL variable method and just added both production & staging frontend URLs as Allowed Hosts